### PR TITLE
docs: add comprehensive documentation with MkDocs Material

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.cache/pip
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material
+          pip install mkdocstrings[python]
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          cname: false

--- a/AGENT.md
+++ b/AGENT.md
@@ -277,6 +277,64 @@ Reviewers look for:
 
 ## Documentation Standards
 
+### Keep Documentation Up-to-Date ⚠️
+
+**CRITICAL**: Documentation must be updated alongside code changes. This is mandatory, not optional.
+
+#### When to Update Documentation
+
+After **ANY** code change, check if these need updates:
+
+1. **CHANGELOG.md** - ALWAYS update for:
+   - New features (Added section)
+   - Bug fixes (Fixed section)
+   - Breaking changes (Changed section)
+   - Deprecated features (Deprecated section)
+   - Add entry under "Unreleased" or upcoming version
+
+2. **ROADMAP.md** - Update when:
+   - Completing planned features (move from future → completed)
+   - Adding new planned features
+   - Changing timelines or priorities
+   - Update "Current Version" and "Last Updated" in footer
+
+3. **User Documentation** (`docs/`) - Update when:
+   - Adding new features or APIs
+   - Changing behavior of existing features
+   - Adding new examples
+   - Files to check: `docs/quickstart.md`, concept guides, API reference
+
+4. **README.md** - Update when:
+   - Adding major features (update "Supported Features" section)
+   - Changing installation or quick start examples
+   - Updating comparison table with other SDKs
+   - Adding new examples directory
+
+5. **Examples** - Update when:
+   - API signatures change
+   - Best practices change
+   - New features are added
+
+#### Documentation Update Checklist
+
+Before submitting PR:
+- [ ] CHANGELOG.md updated with changes
+- [ ] ROADMAP.md updated if completing planned features
+- [ ] User documentation updated if user-facing changes
+- [ ] README.md updated if major feature or quick start affected
+- [ ] Examples still build and run correctly
+- [ ] Godoc comments added/updated for public APIs
+
+#### AI Assistant Reminder
+
+When making code changes:
+1. Identify all affected documentation
+2. Update documentation in the same commit/PR
+3. Use conventional commit messages that indicate doc updates:
+   - `feat(guardrails): add XYZ guardrail` → Update CHANGELOG, docs/guardrails.md
+   - `fix(runner): correct timeout handling` → Update CHANGELOG, possibly README
+   - `docs: update quickstart guide` → Documentation-only change
+
 ### Godoc Comments
 All exported types, functions, and methods must have godoc comments:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [v0.2.3] - 2026-01-19
+
+### Added
+
+**Enhanced Error Handling**:
+- Production-grade error types (`RateLimitError`, `TimeoutError`, `NetworkError`, `ErrorContext`)
+- 4 backoff strategies (Fixed, Linear, Exponential, Custom)
+- `RetryWithBackoff` function with context cancellation support
+- Crypto-secure jitter using `crypto/rand`
+
+**Advanced Guardrails**:
+- **Content Length Guardrail**: 3 counting modes (characters, words, lines)
+- **Rate Limiting Guardrail**: Distributed-ready with token bucket algorithm
+  - Per-user, per-agent, per-IP, or global limiting
+  - Pluggable backend interface (in-memory included)
+  - Thread-safe concurrent execution
+  - Custom key functions
+- **Profanity Detection**: Pattern-based toxicity filtering
+  - Comprehensive word lists with severity levels (Low/Medium/High)
+  - Leetspeak normalization (@ → a, $ → s, ! → i, etc.)
+  - Custom word list support
+- **Secrets Detection**: Credential leakage prevention
+  - 12 secret type patterns (AWS, GitHub, Google, JWT, passwords, private keys, etc.)
+  - Custom regex pattern support
+- **Prompt Injection Detection**: LLM security guardrail
+  - 13 attack pattern detection (instruction override, role manipulation, jailbreak, etc.)
+  - Delimiter and encoding attack detection
+  - Case-insensitive matching
+
+### Changed
+- Improved test coverage to 98.1% on guardrails
+- Enhanced linting compliance (all checks passing)
+
+### Fixed
+- Edge case handling in guardrail tests (80/85 tests passing, 94% pass rate)
+
+---
+
+## [v0.2.2] - 2026-01-16
+
+### Added
+- **OpenAI Conversations API Session**: Cloud-based session persistence
+  - Integration with OpenAI's Conversations API for distributed session management
+  - Automatic conversation creation and message synchronization
+  - Example: `examples/11_conversations_session/`
+
+### Changed
+- Updated session documentation to include Conversations API backend
+
+---
+
+## [v0.2.1] - 2026-01-13
+
+### Added
+- **OpenAI Moderation API Guardrail**: Official content moderation integration
+  - 13 moderation categories (hate, violence, sexual content, self-harm, etc.)
+  - Configurable thresholds per category
+  - Support for text-only and multimodal content
+  - Example: `examples/08_guardrails_demo/` updated with moderation
+
+### Changed
+- Enhanced guardrail framework to support async API-based validation
+
+---
+
+## [v0.2.0] - 2026-01-16
+
+### Added
+
+**Guardrails Framework**:
+- Pluggable guardrail interface for input/output validation
+- Built-in guardrails:
+  - **PII Detection**: Email, phone, SSN, credit card detection
+  - **URL Filtering**: Blocklist/allowlist based URL validation
+  - **Custom Regex**: Pattern-based validation with custom rules
+- Tripwire support (halt execution on guardrail failure)
+- Examples: `examples/08_guardrails_demo/`
+
+**Sessions Framework**:
+- Session interface for conversation persistence
+- **In-Memory Session**: Thread-safe, zero dependencies
+- **File-Based Session**: JSON files with atomic writes, zero dependencies
+- Automatic history management integrated into `Runner.Run()`
+- Examples: `examples/09_sessions_demo/`, `examples/10_advanced_v02/`
+
+### Changed
+- `Runner.Run()` signature updated to use functional options pattern
+- Added `WithGuardrails()` and `WithSession()` run options
+- 32 new tests (20 guardrail tests + 12 session tests)
+
+### Fixed
+- Improved error handling for guardrail and session operations
+
+---
+
+## [v0.1.0] - 2026-01-12
+
+### Added
+
+**Core Foundation**:
+- `Agent` type with configurable behavior (instructions, tools, model, temperature)
+- `Runner` for agent execution orchestration
+- `Tool` interface for function calling
+  - `FunctionTool`: Execute Go functions from agent responses
+  - `HandoffTool`: Transfer control between agents
+- Multi-agent workflows with automatic handoffs
+- Lifecycle hooks (`OnBeforeRun`, `OnAfterRun`)
+- `RunConfig` for execution control (max_turns, timeout, debug mode)
+- Context variables for state passing between agents and tools
+- Usage tracking (token consumption and costs)
+- Execution steps recording
+
+**Structured Outputs**:
+- JSON schema builder with fluent API (`internal/jsonschema`)
+- Complete JSON schema support (objects, arrays, primitives, validation)
+- OpenAI Structured Outputs integration via `ResponseFormat`
+- Schema validation and type-safe JSON responses
+
+**Error Handling**:
+- Custom error types for better debugging
+- Error wrapping with contextual information
+
+**Examples**:
+- `examples/01_basic/`: Hello world agent
+- `examples/02_tools/`: Tool calling demonstration
+- `examples/03_handoffs/`: Agent handoffs
+- `examples/04_lifecycle_hooks/`: Before/after run hooks
+- `examples/05_config_usage/`: RunConfig usage
+- `examples/06_structured_output/`: JSON schema outputs
+- `examples/07_complex_schema/`: Nested schema validation
+
+### Changed
+- Initial public release
+
+---
+
+## Version Links
+
+- [v0.2.3](https://github.com/MitulShah1/openai-agents-go/releases/tag/v0.2.3)
+- [v0.2.2](https://github.com/MitulShah1/openai-agents-go/releases/tag/v0.2.2)
+- [v0.2.1](https://github.com/MitulShah1/openai-agents-go/releases/tag/v0.2.1)
+- [v0.2.0](https://github.com/MitulShah1/openai-agents-go/releases/tag/v0.2.0)
+- [v0.1.0](https://github.com/MitulShah1/openai-agents-go/releases/tag/v0.1.0)
+
+---
+
+## Future Releases
+
+See [ROADMAP.md](./ROADMAP.md) for planned features:
+- v0.3.0: Database session backends (SQLite, Redis, PostgreSQL), Tracing & Observability
+- v0.4.0: Streaming support, Performance optimizations
+- v1.0.0: Stable release with API guarantees
+- v1.1.0+: Advanced integrations (Batch API, Realtime API, RAG, MCP)

--- a/README.md
+++ b/README.md
@@ -260,11 +260,12 @@ cd examples/11_conversations_session && go run main.go
 
 ## Documentation
 
-- 📚 [API Documentation](https://pkg.go.dev/github.com/MitulShah1/openai-agents-go)
+- 📖 **[Documentation Site](https://mitulshah1.github.io/openai-agents-go/)** - Comprehensive guides and tutorials
+- 📚 [API Documentation](https://pkg.go.dev/github.com/MitulShah1/openai-agents-go) - GoDoc reference
+- 📝 [CHANGELOG](./CHANGELOG.md) - Version history and release notes
 - 🤖 [AI Assistant Guide](./AGENT.md) - For Claude, Copilot, etc.
 - 🗺️ [Development Roadmap](./ROADMAP.md)
-- 📝 [Examples Directory](./examples)
-- 🔧 [OpenAI Go SDK](https://github.com/openai/openai-go)
+- 📋 [Examples Directory](./examples)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,121 +31,29 @@ Future    │ v1.1.0+ - Advanced Integrations
 
 ## Version Roadmap
 
-### v0.1.0 - Core Foundation 🏗️ ✅ COMPLETE
+### Completed Releases ✅
 
-**Released**: 2026-01-12  
-**Status**: ✅ Complete  
-**Dependencies**: Zero external dependencies
+For detailed release notes, see [CHANGELOG.md](./CHANGELOG.md).
 
-#### Features
-- ✅ Enhanced Agent configuration (temperature, max_tokens, lifecycle hooks)
-- ✅ RunConfig for execution control (max_turns, timeout, debug mode)
-- ✅ Custom error types for better error handling
-- ✅ Usage tracking (tokens, costs)
-- ✅ Execution steps recording
-- ✅ Function schema generation from Go structs
-- ✅ Improved tool execution with context
-- ✅ **Structured Outputs** - JSON schema builder with fluent API
-  - Complete JSON schema support (objects, arrays, primitives, validation)
-  - OpenAI Structured Outputs integration
-  - Response format control (text vs JSON schema)
-  - Modular `internal/jsonschema` package
+#### v0.2.3 - Enhanced Guardrails & Error Handling (2026-01-19) ✅
+- 9+ production-ready guardrails (PII, Moderation, Rate Limiting, Profanity, Secrets, Prompt Injection, etc.)
+- Production-grade error handling with 4 retry strategies
+- 98.1% test coverage on guardrails
 
-#### Use Cases
-- Simple chatbots
-- Basic tool-calling agents
-- Single-turn interactions
-- Development and testing
+#### v0.2.2 - Conversations API (2026-01-16) ✅
+- Cloud-based session persistence via OpenAI Conversations API
 
----
+#### v0.2.1 - Moderation Guardrail (2026-01-13) ✅
+- OpenAI Moderation API integration (13 categories)
 
-### v0.2.0 - Guardrails & Sessions 🛡️ ✅ COMPLETE
+#### v0.2.0 - Guardrails & Sessions (2026-01-16) ✅
+- Guardrail framework with PII, URL filtering, custom regex
+- Session framework with in-memory, file-based, and cloud backends
 
-**Released**: 2026-01-16  
-**Status**: ✅ Complete  
-**Dependencies**: Zero external dependencies
-
-#### Features
-
-**Guardrails** (Input/Output Validation):
-- ✅ Guardrail framework with pluggable validators
-- ✅ OpenAI Moderation API integration (13 categories)
-- ✅ PII detection (email, phone, SSN, credit card)
-- ✅ URL filtering (blocklist/allowlist)
-- ✅ Custom regex-based validation
-- ✅ Tripwire support (halt on failure)
-
-**Sessions** (Conversation Persistence):
-- ✅ Session interface for pluggable backends
-- ✅ In-Memory session (thread-safe, zero deps)
-- ✅ File-Based session (JSON files with atomic writes, zero deps)
-- ✅ OpenAI Conversations API session (cloud-based persistence)
-- ✅ Automatic history management (load/save integrated in Runner)
-
-**What's Complete**:
-- ✅ 32 tests passing (20 guardrail + 12 session)
-- ✅ Zero new dependencies added
-- ✅ Runner.Run signature updated (functional options pattern)
-- ✅ All examples working (01-11)
-- ✅ Comprehensive documentation and godoc
-- ✅ Examples: Basic, Tools, Handoffs, Lifecycle, Config, Structured Output, Guardrails, Sessions
-
-#### Use Cases
-- Multi-turn conversations
-- Chatbots with memory
-- Content moderation
-- Compliance checks (PII protection)
-- Production deployments with cloud sessions
-
----
-
-### v0.2.3 - Enhanced Guardrails & Error Handling 🛡️⚡ ✅ COMPLETE
-
-**Released**: 2026-01-19  
-**Status**: ✅ Complete  
-**Dependencies**: Zero external dependencies
-
-#### Features
-
-**Enhanced Error Handling**:
-- ✅ Production-grade error types (RateLimitError, TimeoutError, NetworkError, ErrorContext)
-- ✅ 4 backoff strategies (Fixed, Linear, Exponential, Custom)
-- ✅ RetryWithBackoff function with context cancellation support
-- ✅ Crypto-secure jitter using crypto/rand
-
-**Advanced Guardrails**:
-- ✅ **Content Length Guardrail**: 3 counting modes (characters, words, lines)
-- ✅ **Rate Limiting Guardrail**: Distributed-ready with token bucket algorithm
-  - Per-user, per-agent, per-IP, or global limiting
-  - Pluggable backend interface (in-memory included)
-  - Thread-safe concurrent execution
-  - Custom key functions
-- ✅ **Profanity Detection**: Pattern-based toxicity filtering
-  - Comprehensive word lists with severity levels (Low/Medium/High)
-  - Leetspeak normalization (@ → a, $ → s, ! → i, etc.)
-  - Custom word list support
-- ✅ **Secrets Detection**: Credential leakage prevention
-  - 12 secret type patterns (AWS, GitHub, Google, JWT, passwords, private keys, etc.)
-  - Custom regex pattern support
-- ✅ **Prompt Injection Detection**: LLM security guardrail
-  - 13 attack pattern detection (instruction override, role manipulation, jailbreak, etc.)
-  - Delimiter and encoding attack detection
-  - Case-insensitive matching
-
-**Quality Metrics**:
-- ✅ 98.1% test coverage on guardrails
-- ✅ 80/85 tests passing (94% pass rate)
-- ✅ All linting checks pass (gofmt, goimports, golangci-lint)
-- ✅ Race detection tests passing
-- ✅ ~1,800 lines of production code
-- ✅ ~1,600 lines of test code
-
-#### Use Cases
-- Multi-agent security (prompt injection, secrets detection)
-- Content moderation and compliance (profanity, length limits)
-- API protection (rate limiting, retry strategies)
-- Production error handling with automatic retries
-- Distributed systems with pluggable rate limiting backends
+#### v0.1.0 - Core Foundation (2026-01-12) ✅
+- Agent, Runner, Tool abstractions
+- Structured outputs with JSON schema builder
+- Multi-agent workflows and handoffs
 
 ---
 
@@ -438,7 +346,9 @@ We welcome contributions! Please:
 
 ---
 
-**Last Updated**: 2026-01-17  
-**Current Version**: v0.2.0 ✅  
-**Current Focus**: v0.3.0 - Enhanced Guardrails, Database Backends & Tracing  
+**Last Updated**: 2026-01-19  
+**Current Version**: v0.2.3 ✅  
+**Next Focus**: v0.3.0 - Database Backends, Tracing & Composition  
 **SDK Version**: openai-go/v3 v3.16.0
+
+See [CHANGELOG.md](./CHANGELOG.md) for detailed release history.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,178 @@
+# Agents
+
+Agents are the core building blocks of the SDK. An agent represents an AI model configured with specific behavior, tools, and capabilities.
+
+## Creating an Agent
+
+The simplest way to create an agent is with `NewAgent()`:
+
+```go
+agent := agents.NewAgent("My Agent")
+agent.Instructions = "You are a helpful coding assistant"
+```
+
+## Agent Configuration
+
+### Basic Properties
+
+```go
+agent := agents.NewAgent("CodeHelper")
+
+// Required: Instructions define the agent's behavior
+agent.Instructions = "You are an expert Go programmer who helps with code reviews"
+
+// Optional: Model selection (defaults to gpt-4o)
+agent.Model = "gpt-4"
+agent.Model = "gpt-4-turbo"
+agent.Model = "gpt-3.5-turbo"
+
+// Optional: Temperature controls randomness (0.0 - 2.0)
+agent.Temperature = 0.7  // More creative
+agent.Temperature = 0.0  // More deterministic
+
+// Optional: Max tokens for responses
+agent.MaxTokens = 500
+```
+
+### Tools
+
+Agents can use tools to perform actions:
+
+```go
+agent.Tools = []agents.Tool{
+    myCustomTool,
+    agents.HandoffTool(otherAgent, "Transfer to specialist"),
+}
+```
+
+See the [Tools documentation](tools.md) for more details.
+
+### Response Format
+
+Control output format with structured outputs:
+
+```go
+import "github.com/MitulShah1/openai-agents-go/internal/jsonschema"
+
+schema := jsonschema.Object().
+    WithProperty("summary", jsonschema.String()).
+    WithRequired("summary")
+
+agent.ResponseFormat = jsonschema.JSONSchema("response", schema)
+```
+
+See [Structured Outputs](structured_outputs.md) for details.
+
+## Lifecycle Hooks
+
+Execute code before and after agent runs:
+
+```go
+agent.OnBeforeRun = func(ctx context.Context, agent *agents.Agent) error {
+    fmt.Println("Starting agent:", agent.Name)
+    return nil
+}
+
+agent.OnAfterRun = func(ctx context.Context, agent *agents.Agent, result *agents.Result) error {
+    fmt.Printf("Agent completed. Tokens used: %d\n", result.Usage.TotalTokens)
+    return nil
+}
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    // Create fully configured agent
+    agent := agents.NewAgent("ProductivityCoach")
+    agent.Instructions = `You are a productivity coach who helps users:
+    - Break down large tasks
+    - Create actionable plans
+    - Provide motivation and accountability`
+    
+    agent.Model = "gpt-4"
+    agent.Temperature = 0.8
+    agent.MaxTokens = 1000
+    
+    agent.OnBeforeRun = func(ctx context.Context, a *agents.Agent) error {
+        fmt.Println("🤖 Agent starting...")
+        return nil
+    }
+    
+    agent.OnAfterRun = func(ctx context.Context, a *agents.Agent, r *agents.Result) error {
+        fmt.Printf("✅ Completed in %d steps\n", len(r.Steps))
+        return nil
+    }
+
+    // Run the agent
+    client := openai.NewClient(/* ... */)
+    runner := agents.NewRunner(&client)
+    
+    result, err := runner.Run(
+        context.Background(),
+        agent,
+        []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("Help me organize my week"),
+        },
+        nil,
+        nil,
+    )
+    
+    if err != nil {
+        panic(err)
+    }
+    
+    fmt.Println(result.FinalOutput)
+}
+```
+
+## Best Practices
+
+### Clear Instructions
+
+✅ **Good**: Specific, actionable instructions
+```go
+agent.Instructions = `You are a code reviewer. For each code submission:
+1. Check for bugs and security issues
+2. Suggest improvements for readability
+3. Verify tests are present
+4. Provide specific line-by-line feedback`
+```
+
+❌ **Bad**: Vague instructions
+```go
+agent.Instructions = "You help with code"
+```
+
+### Model Selection
+
+- **gpt-4o**: Best balance of speed and capability (default)
+- **gpt-4**: Most capable, slower and more expensive
+- **gpt-4-turbo**: Fast and capable
+- **gpt-3.5-turbo**: Fastest and cheapest, less capable
+
+### Temperature Guidelines
+
+| Temperature | Use Case | Example |
+|------------|----------|---------|
+| 0.0 - 0.3 | Deterministic tasks | Code generation, data extraction |
+| 0.4 - 0.7 | Balanced | General assistance, Q&A |
+| 0.8 - 1.0 | Creative tasks | Writing, brainstorming |
+| 1.0+ | Highly creative | Poetry, experimental |
+
+## Related Topics
+
+- [Running Agents](running_agents.md) - Execute agents and handle results
+- [Tools](tools.md) - Give agents capabilities
+- [Handoffs](handoffs.md) - Transfer between agents
+- [Structured Outputs](structured_outputs.md) - Type-safe responses

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,370 @@
+# Guardrails
+
+Guardrails provide input and output validation to ensure your agents handle content safely and comply with your requirements.
+
+## Overview
+
+The guardrail framework allows you to:
+- **Validate inputs** before sending to the LLM
+- **Validate outputs** before returning to users
+- **Chain multiple guardrails** for comprehensive protection
+- **Use tripwires** to halt execution on critical failures
+
+## Built-in Guardrails
+
+The SDK includes 9+ production-ready guardrails:
+
+| Guardrail | Purpose | Version |
+|-----------|---------|---------|
+| PII Detection | Detect emails, phones, SSNs, credit cards | v0.2.0 |
+| URL Filtering | Block/allow specific URLs | v0.2.0 |
+| Custom Regex | Pattern-based validation | v0.2.0 |
+| Moderation API | OpenAI's content moderation (13 categories) | v0.2.1 |
+| Content Length | Limit characters, words, or lines | v0.2.3 |
+| Rate Limiting | Prevent abuse with token bucket algorithm | v0.2.3 |
+| Profanity Detection | Filter toxic content with severity levels | v0.2.3 |
+| Secrets Detection | Prevent credential leakage (12 types) | v0.2.3 |
+| Prompt Injection | Detect LLM security attacks (13 patterns) | v0.2.3 |
+
+## Basic Usage
+
+```go
+import "github.com/MitulShah1/openai-agents-go/guardrail/builtin"
+
+func main() {
+    // Create guardrails
+    piiGuardrail := builtin.NewPIIGuardrail("PII Protection", true)
+    
+    // Run agent with guardrails
+    result, err := runner.Run(
+        ctx,
+        agent,
+        messages,
+        nil,
+        agents.WithGuardrails([]agents.Guardrail{piiGuardrail}),
+    )
+}
+```
+
+## PII Detection
+
+Detects and blocks personally identifiable information:
+
+```go
+pii := builtin.NewPIIGuardrail("No PII", true)
+
+// Detects:
+// - Email addresses: user@example.com
+// - Phone numbers: (555) 123-4567, +1-555-123-4567
+// - SSNs: 123-45-6789
+// - Credit cards: 4111-1111-1111-1111
+```
+
+## URL Filtering
+
+Control which URLs are allowed:
+
+```go
+// Block specific domains
+blocklist := []string{"malicious.com", "spam.net"}
+urlGuard := builtin.NewURLGuardrail("URL Filter", blocklist, []string{}, true)
+
+// Allow only specific domains
+allowlist := []string{"example.com", "trusted.org"}
+urlGuard := builtin.NewURLGuardrail("URL Filter", []string{}, allowlist, true)
+```
+
+## Content Length Limits
+
+Limit content size with multiple counting modes:
+
+```go
+import "github.com/MitulShah1/openai-agents-go/guardrail/builtin"
+
+// Limit characters
+charLimit := builtin.NewContentLengthGuardrail(
+    "Character Limit",
+    1000,  // max length
+    builtin.CountCharacters,
+    false, // not a tripwire
+)
+
+// Limit words
+wordLimit := builtin.NewContentLengthGuardrail(
+    "Word Limit",
+    200,
+    builtin.CountWords,
+    false,
+)
+
+// Limit lines
+lineLimit := builtin.NewContentLengthGuardrail(
+    "Line Limit",
+    50,
+    builtin.CountLines,
+    false,
+)
+```
+
+## Rate Limiting
+
+Prevent abuse with distributed-ready rate limiting:
+
+```go
+import (
+    "time"
+    "github.com/MitulShah1/openai-agents-go/guardrail/builtin"
+)
+
+// Global rate limit
+rateLimiter := builtin.NewRateLimitGuardrail(
+    "API Rate Limit",
+    100,                    // 100 requests
+    time.Minute,            // per minute
+    builtin.NewMemoryBackend(),
+    nil,                    // global limit
+    true,                   // tripwire
+)
+
+// Per-user rate limit
+perUserLimit := builtin.NewRateLimitGuardrail(
+    "Per-User Limit",
+    10,
+    time.Minute,
+    builtin.NewMemoryBackend(),
+    func(text string, isInput bool) string {
+        // Extract user ID from context
+        return "user-123"
+    },
+    true,
+)
+```
+
+## Profanity Detection
+
+Filter toxic content with severity levels:
+
+```go
+// Block all profanity
+profanity := builtin.NewProfanityGuardrail("Profanity Filter", true)
+
+// Custom word list
+custom := builtin.NewProfanityGuardrailWithWords(
+    "Custom Filter",
+    map[string]builtin.Severity{
+        "badword1": builtin.SeverityHigh,
+        "badword2": builtin.SeverityMedium,
+    },
+    true,
+)
+```
+
+Features:
+- Comprehensive word lists (Low, Medium, High severity)
+- Leetspeak normalization (@ → a, $ → s, ! → i)
+- Case-insensitive matching
+
+## Secrets Detection
+
+Prevent credential leakage:
+
+```go
+secrets := builtin.NewSecretsGuardrail("Secrets Protection", true)
+
+// Detects 12 secret types:
+// - AWS Access Keys
+// - GitHub Personal Access Tokens
+// - Google API Keys
+// - JWT Tokens
+// - Private SSH Keys
+// - Database Connection Strings
+// - API Keys (generic patterns)
+// - OAuth Tokens
+// - And more...
+```
+
+## Prompt Injection Detection
+
+Protect against LLM security attacks:
+
+```go
+injection := builtin.NewPromptInjectionGuardrail("Injection Protection", true)
+
+// Detects 13 attack patterns:
+// - Instruction override attempts
+// - Role manipulation
+// - Jailbreak attempts
+// - Delimiter attacks
+// - Encoding attacks (base64, hex, unicode)
+// - System prompt extraction
+// - And more...
+```
+
+## OpenAI Moderation API
+
+Use OpenAI's official content moderation:
+
+```go
+import "github.com/openai/openai-go"
+
+client := openai.NewClient(/* ... */)
+
+moderation := builtin.NewModerationGuardrail(
+    "Content Moderation",
+    &client,
+    nil,  // Use default thresholds
+    true, // tripwire
+)
+
+// 13 moderation categories:
+// - hate, hate/threatening
+// - harassment, harassment/threatening
+// - self-harm (intent, instructions)
+// - sexual, sexual/minors
+// - violence, violence/graphic
+// - illicit, illicit/violent
+```
+
+Custom thresholds:
+
+```go
+thresholds := map[string]float64{
+    "hate": 0.5,
+    "violence": 0.7,
+}
+
+moderation := builtin.NewModerationGuardrail(
+    "Custom Moderation",
+    &client,
+    thresholds,
+    true,
+)
+```
+
+## Custom Regex Guardrails
+
+Create pattern-based validation:
+
+```go
+// Block specific patterns
+patterns := []string{
+    `\b\d{3}-\d{2}-\d{4}\b`,  // SSN pattern
+    `password\s*[:=]\s*\S+`,   // Password assignments
+}
+
+regex := builtin.NewRegexGuardrail("Pattern Filter", patterns, true)
+```
+
+## Tripwires
+
+Tripwires halt execution immediately on failure:
+
+```go
+// Tripwire ON - execution stops if violated
+critical := builtin.NewPIIGuardrail("Critical PII", true)
+
+// Tripwire OFF - logs violation but continues
+warning := builtin.NewPIIGuardrail("PII Warning", false)
+```
+
+## Chaining Guardrails
+
+Combine multiple guardrails:
+
+```go
+guardrails := []agents.Guardrail{
+    builtin.NewPIIGuardrail("PII", true),
+    builtin.NewSecretsGuardrail("Secrets", true),
+    builtin.NewPromptInjectionGuardrail("Injection", true),
+    builtin.NewContentLengthGuardrail("Length", 1000, builtin.CountCharacters, false),
+    builtin.NewProfanityGuardrail("Profanity", false),
+}
+
+result, err := runner.Run(
+    ctx,
+    agent,
+    messages,
+    nil,
+    agents.WithGuardrails(guardrails),
+)
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/MitulShah1/openai-agents-go/guardrail/builtin"
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    client := openai.NewClient(/* ... */)
+    runner := agents.NewRunner(&client)
+
+    agent := agents.NewAgent("SecureAgent")
+    agent.Instructions = "You are a helpful assistant"
+
+    // Production guardrail stack
+    guardrails := []agents.Guardrail{
+        // Critical: Block dangerous content
+        builtin.NewPIIGuardrail("PII Protection", true),
+        builtin.NewSecretsGuardrail("Secrets Protection", true),
+        builtin.NewPromptInjectionGuardrail("Injection Defense", true),
+        
+        // Moderation
+        builtin.NewModerationGuardrail("Content Moderation", &client, nil, true),
+        builtin.NewProfanityGuardrail("Profanity Filter", false),
+        
+        // Rate limiting
+        builtin.NewRateLimitGuardrail(
+            "API Rate Limit",
+            100,
+            time.Minute,
+            builtin.NewMemoryBackend(),
+            nil,
+            true,
+        ),
+        
+        // Quality control
+        builtin.NewContentLengthGuardrail("Length Limit", 2000, builtin.CountCharacters, false),
+    }
+
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Hello!"),
+    }
+
+    result, err := runner.Run(
+        context.Background(),
+        agent,
+        messages,
+        nil,
+        agents.WithGuardrails(guardrails),
+    )
+
+    if err != nil {
+        fmt.Println("Guardrail violation:", err)
+        return
+    }
+
+    fmt.Println(result.FinalOutput)
+}
+```
+
+## Best Practices
+
+1. **Use tripwires for critical guardrails** (PII, secrets, injections)
+2. **Log violations for non-tripwire guardrails** (profanity, length)
+3. **Layer guardrails** from most to least critical
+4. **Test guardrails** with known violation cases
+5. **Monitor guardrail metrics** in production
+
+## API Reference
+
+See [Guardrails API Reference](ref/guardrails/index.md) for detailed API documentation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,154 @@
+# OpenAI Agents Go SDK
+
+[![CI](https://github.com/MitulShah1/openai-agents-go/workflows/CI/badge.svg)](https://github.com/MitulShah1/openai-agents-go/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/MitulShah1/openai-agents-go)](https://goreportcard.com/report/github.com/MitulShah1/openai-agents-go)
+[![GoDoc](https://pkg.go.dev/badge/github.com/MitulShah1/openai-agents-go.svg)](https://pkg.go.dev/github.com/MitulShah1/openai-agents-go)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A lightweight, powerful Go framework for building multi-agent workflows with OpenAI's API. Build production-ready AI agents with tool calling, handoffs, structured outputs, and comprehensive guardrails.
+
+!!! note "Community Project"
+    This is an **unofficial** community-maintained SDK inspired by the official [OpenAI Agents Python SDK](https://github.com/openai/openai-agents-python) and [OpenAI Agents JavaScript SDK](https://github.com/openai/openai-agents-js), but is not affiliated with or endorsed by OpenAI.
+
+## Why Use the Agents SDK?
+
+The Agents SDK simplifies building multi-agent AI applications with these key advantages:
+
+- **🚀 Zero Dependencies**: Core SDK has no external dependencies beyond the official OpenAI Go SDK
+- **🔒 Type Safety**: Full Go compile-time type safety with generics support
+- **🛡️ Production-Ready Guardrails**: 9+ built-in guardrails including PII detection, rate limiting, profanity filtering, and prompt injection detection
+- **💾 Flexible Sessions**: Multiple storage backends (in-memory, file-based, cloud)
+- **🔧 Powerful Tool System**: Seamlessly integrate Go functions as agent tools
+- **🤝 Multi-Agent Workflows**: Hand off between specialized agents dynamically
+- **📊 Structured Outputs**: Schema-validated JSON responses with fluent API
+- **⚡ Performance**: Leverages Go's concurrency and performance characteristics
+
+## Quick Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/openai/openai-go"
+    "github.com/openai/openai-go/option"
+)
+
+func main() {
+    // Initialize OpenAI client
+    client := openai.NewClient(option.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
+    runner := agents.NewRunner(&client)
+
+    // Create an agent
+    agent := agents.NewAgent("Assistant")
+    agent.Instructions = "You are a helpful assistant"
+
+    // Run the agent
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Write a haiku about Go programming"),
+    }
+
+    result, err := runner.Run(context.Background(), agent, messages, nil, nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(result.FinalOutput)
+}
+```
+
+## Installation
+
+```bash
+go get github.com/MitulShah1/openai-agents-go@latest
+```
+
+**Requirements**: Go 1.24 or higher
+
+## Supported Features
+
+| Feature | Status | Version |
+|---------|--------|---------|
+| Multi-Agent Workflows | ✅ Complete | v0.1.0 |
+| Tool Integration | ✅ Complete | v0.1.0 |
+| Handoffs | ✅ Complete | v0.1.0 |
+| Structured Outputs | ✅ Complete | v0.1.0 |
+| Lifecycle Hooks | ✅ Complete | v0.1.0 |
+| **Guardrails** | ✅ Complete | v0.2.0+ |
+| **Sessions** | ✅ Complete | v0.2.0+ |
+| Context Variables | ✅ Complete | v0.1.0 |
+| Usage Tracking | ✅ Complete | v0.1.0 |
+| Error Handling | ✅ Enhanced | v0.2.3 |
+| Streaming | 🔮 Planned | v0.4.0 |
+| Tracing & Observability | 🔮 Planned | v0.3.0 |
+| Database Session Backends | 🔮 Planned | v0.3.0 |
+
+See the [CHANGELOG](https://github.com/MitulShah1/openai-agents-go/blob/main/CHANGELOG.md) for detailed release notes.
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :material-clock-fast:{ .lg .middle } __Quickstart__
+
+    ---
+
+    Get started quickly with our comprehensive quickstart guide
+
+    [:octicons-arrow-right-24: Get Started](quickstart.md)
+
+-   :material-book-open-variant:{ .lg .middle } __Core Concepts__
+
+    ---
+
+    Learn about agents, tools, handoffs, and more
+
+    [:octicons-arrow-right-24: Learn Concepts](agents.md)
+
+-   :material-code-braces:{ .lg .middle } __API Reference__
+
+    ---
+
+    Detailed API documentation for all types and functions
+
+    [:octicons-arrow-right-24: API Docs](ref/index.md)
+
+-   :material-github:{ .lg .middle } __Examples__
+
+    ---
+
+    Browse 11+ working examples on GitHub
+
+    [:octicons-arrow-right-24: View Examples](https://github.com/MitulShah1/openai-agents-go/tree/main/examples)
+
+</div>
+
+## Comparison with Official SDKs
+
+| Feature | [Python SDK](https://github.com/openai/openai-agents-python) | [JavaScript SDK](https://github.com/openai/openai-agents-js) | **Go SDK (This)** |
+|---------|---------------|--------------|---------------| | Agents | ✅ | ✅ | ✅ |
+| Tools | ✅ | ✅ | ✅ |
+| Handoffs | ✅ | ✅ | ✅ |
+| Structured Outputs | ✅ | ✅ | ✅ |
+| Streaming | ✅ | ✅ | 🔮 Planned |
+| Guardrails | ✅ | ✅ | ✅ (9+ guardrails) |
+| Tracing | ✅ | ✅ | 🔮 Planned |
+| Voice Agents | ❌ | ✅ | 🔮 Future |
+| **Type Safety** | ⚠️ Runtime | ⚠️ TypeScript | ✅ Compile-time |
+| **Zero Dependencies** | ❌ | ❌ | ✅ (core only) |
+
+## Community & Support
+
+- 🐛 [Report Issues](https://github.com/MitulShah1/openai-agents-go/issues)
+- 💬 [Discussions](https://github.com/MitulShah1/openai-agents-go/discussions)
+- 📖 [Roadmap](https://github.com/MitulShah1/openai-agents-go/blob/main/ROADMAP.md)
+- ⭐ Star the repo if you find it useful!
+
+---
+
+**Made with ❤️ by the Go community**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,306 @@
+# Quickstart Guide
+
+This guide will help you get started with the OpenAI Agents Go SDK in minutes.
+
+## Prerequisites
+
+- Go 1.24 or higher
+- OpenAI API key ([Get one here](https://platform.openai.com/api-keys))
+
+## Installation
+
+```bash
+go get github.com/MitulShah1/openai-agents-go@latest
+```
+
+## Your First Agent
+
+Let's create a simple agent that can answer questions:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    "os"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/openai/openai-go"
+    "github.com/openai/openai-go/option"
+)
+
+func main() {
+    // 1. Initialize OpenAI client
+    client := openai.NewClient(option.WithAPIKey(os.Getenv("OPENAI_API_KEY")))
+    runner := agents.NewRunner(&client)
+
+    // 2. Create an agent
+    agent := agents.NewAgent("Assistant")
+    agent.Instructions = "You are a helpful assistant who answers questions concisely"
+    agent.Model = "gpt-4" // Optional: defaults to gpt-4o
+
+    // 3. Create user message
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("What is the capital of France?"),
+    }
+
+    // 4. Run the agent
+    result, err := runner.Run(context.Background(), agent, messages, nil, nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // 5. Print the response
+    fmt.Println(result.FinalOutput)
+    // Output: Paris is the capital of France.
+}
+```
+
+## Adding Tools
+
+Agents can call Go functions as tools. Here's how to add a weather tool:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    client := openai.NewClient(/* ... */)
+    runner := agents.NewRunner(&client)
+
+    // 1. Define a tool function
+    weatherTool := agents.FunctionTool(
+        "get_weather",
+        "Get the current weather for a city",
+        map[string]any{
+            "type": "object",
+            "properties": map[string]any{
+                "city": map[string]any{
+                    "type":        "string",
+                    "description": "The city name",
+                },
+            },
+            "required": []string{"city"},
+        },
+        func(args map[string]any, ctx agents.ContextVariables) (any, error) {
+            city := args["city"].(string)
+            // In real app, call weather API here
+            return fmt.Sprintf("The weather in %s is sunny, 72°F", city), nil
+        },
+    )
+
+    // 2. Add tool to agent
+    agent := agents.NewAgent("Weather Agent")
+    agent.Instructions = "You help users check the weather"
+    agent.Tools = []agents.Tool{weatherTool}
+
+    // 3. Run agent with tool
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("What's the weather in Tokyo?"),
+    }
+
+    result, _ := runner.Run(context.Background(), agent, messages, nil, nil)
+    fmt.Println(result.FinalOutput)
+    // Output: The weather in Tokyo is sunny, 72°F
+}
+```
+
+## Agent Handoffs
+
+Hand off between specialized agents:
+
+```go
+package main
+
+import (
+    agents "github.com/MitulShah1/openai-agents-go"
+)
+
+func main() {
+    // 1. Create specialized agent
+    weatherAgent := agents.NewAgent("Weather Specialist")
+    weatherAgent.Instructions = "You are an expert at weather information"
+    weatherAgent.Tools = []agents.Tool{weatherTool} // from previous example
+
+    // 2. Create main agent that can hand off
+    mainAgent := agents.NewAgent("Main Assistant")
+    mainAgent.Instructions = "You coordinate with specialists. Transfer weather questions to the weather specialist."
+    mainAgent.Tools = []agents.Tool{
+        agents.HandoffTool(weatherAgent, "Transfer to weather specialist for weather questions"),
+    }
+
+    // 3. Run - handoffs happen automatically
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("What's the weather in Paris?"),
+    }
+
+    result, _ := runner.Run(ctx, mainAgent, messages, nil, nil)
+    // The runner automatically handles the handoff to weatherAgent
+}
+```
+
+## Structured Outputs
+
+Get type-safe JSON responses with schema validation:
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "github.com/MitulShah1/openai-agents-go/internal/jsonschema"
+)
+
+func main() {
+    // 1. Define JSON schema
+    schema := jsonschema.Object().
+        WithProperty("answer", jsonschema.Integer().WithDescription("The calculated answer")).
+        WithProperty("reasoning", jsonschema.String().WithDescription("Step-by-step reasoning")).
+        WithRequired("answer", "reasoning")
+
+    // 2. Create agent with structured output
+    agent := agents.NewAgent("Math Tutor")
+    agent.Instructions = "Solve math problems and show your reasoning"
+    agent.ResponseFormat = jsonschema.JSONSchema("math_response", schema)
+
+    // 3. Run agent
+    messages := []openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("What is 15 + 27?"),
+    }
+
+    result, _ := runner.Run(ctx, agent, messages, nil, nil)
+
+    // 4. Parse structured output
+    type MathResponse struct {
+        Answer    int    `json:"answer"`
+        Reasoning string `json:"reasoning"`
+    }
+
+    var response MathResponse
+    json.Unmarshal([]byte(result.FinalOutput), &response)
+    
+    fmt.Printf("Answer: %d\nReasoning: %s\n", response.Answer, response.Reasoning)
+}
+```
+
+## Adding Guardrails
+
+Protect your agents with input/output validation:
+
+```go
+package main
+
+import (
+    "github.com/MitulShah1/openai-agents-go/guardrail/builtin"
+)
+
+func main() {
+    // 1. Create guardrails
+    piiGuardrail := builtin.NewPIIGuardrail("No PII allowed", true)
+    urlGuardrail := builtin.NewURLGuardrail("No URLs", []string{}, []string{}, true)
+
+    // 2. Run agent with guardrails
+    result, err := runner.Run(
+        ctx,
+        agent,
+        messages,
+        nil,
+        agents.WithGuardrails([]agents.Guardrail{piiGuardrail, urlGuardrail}),
+    )
+
+    // Guardrails automatically validate input before sending to API
+    // and validate output before returning to user
+}
+```
+
+## Using Sessions
+
+Persist conversation history across runs:
+
+```go
+package main
+
+import (
+    "github.com/MitulShah1/openai-agents-go/session"
+)
+
+func main() {
+    // 1. Create session (in-memory for testing, file-based for production)
+    sess := session.NewMemorySession()
+
+    // 2. Run agent with session
+    result1, _ := runner.Run(
+        ctx,
+        agent,
+        []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("My name is Alice"),
+        },
+        nil,
+        agents.WithSession(sess, "user-123"),
+    )
+
+    // 3. Next run remembers context
+    result2, _ := runner.Run(
+        ctx,
+        agent,
+        []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("What's my name?"),
+        },
+        nil,
+        agents.WithSession(sess, "user-123"),
+    )
+    
+    fmt.Println(result2.FinalOutput)
+    // Output: Your name is Alice.
+}
+```
+
+## Configuration Options
+
+Control agent execution with `RunConfig`:
+
+```go
+package main
+
+import (
+    "time"
+    agents "github.com/MitulShah1/openai-agents-go"
+)
+
+func main() {
+    // Set maximum turns and timeout
+    result, err := runner.Run(
+        ctx,
+        agent,
+        messages,
+        &agents.RunConfig{
+            MaxTurns: 5,                    // Limit agent loops
+            Timeout:  30 * time.Second,     // Overall timeout
+            Debug:    true,                  // Enable debug logging
+        },
+        nil,
+    )
+}
+```
+
+## Next Steps
+
+Now that you've learned the basics, explore more advanced topics:
+
+- **[Agents](agents.md)** - Deep dive into agent configuration
+- **[Tools](tools.md)** - Advanced tool patterns and custom tools
+- **[Handoffs](handoffs.md)** - Multi-agent orchestration
+- **[Guardrails](guardrails.md)** - Comprehensive input/output validation
+- **[Sessions](sessions/index.md)** - Persistent conversation management
+- **[Structured Outputs](structured_outputs.md)** - Complex JSON schemas
+
+Or check out the [Examples](https://github.com/MitulShah1/openai-agents-go/tree/main/examples) on GitHub for complete working code.

--- a/docs/ref/guardrails/index.md
+++ b/docs/ref/guardrails/index.md
@@ -1,0 +1,88 @@
+# Guardrails API Reference
+
+Complete API reference for the guardrail framework and built-in guardrails.
+
+## Guardrail Interface
+
+```go
+type Guardrail interface {
+    Validate(text string, isInput bool) error
+    Name() string
+    IsTripwire() bool
+}
+```
+
+## Built-in Guardrails
+
+### PII Detection
+```go
+func NewPIIGuardrail(name string, isTripwire bool) Guardrail
+```
+
+Detects: emails, phones, SSNs, credit cards
+
+### URL Filtering
+```go
+func NewURLGuardrail(name string, blocklist, allowlist []string, isTripwire bool) Guardrail
+```
+
+### Custom Regex
+```go
+func NewRegexGuardrail(name string, patterns []string, isTripwire bool) Guardrail
+```
+
+### Moderation API
+```go
+func NewModerationGuardrail(name string, client *openai.Client, thresholds map[string]float64, isTripwire bool) Guardrail
+```
+
+### Content Length
+```go
+func NewContentLengthGuardrail(name string, maxLength int, mode CountingMode, isTripwire bool) Guardrail
+
+type CountingMode int
+const (
+    CountCharacters CountingMode = iota
+    CountWords
+    CountLines
+)
+```
+
+### Rate Limiting
+```go
+func NewRateLimitGuardrail(name string, limit int, window time.Duration, backend Backend, keyFunc KeyFunc, isTripwire bool) Guardrail
+
+type Backend interface {
+    Allow(key string, limit int, window time.Duration) (bool, error)
+}
+
+type KeyFunc func(text string, isInput bool) string
+```
+
+### Profanity Detection
+```go
+func NewProfanityGuardrail(name string, isTripwire bool) Guardrail
+func NewProfanityGuardrailWithWords(name string, words map[string]Severity, isTripwire bool) Guardrail
+
+type Severity int
+const (
+    SeverityLow Severity = iota
+    SeverityMedium
+    SeverityHigh
+)
+```
+
+### Secrets Detection
+```go
+func NewSecretsGuardrail(name string, isTripwire bool) Guardrail
+```
+
+### Prompt Injection Detection
+```go
+func NewPromptInjectionGuardrail(name string, isTripwire bool) Guardrail
+```
+
+## See Also
+
+- [Guardrails Guide](../guardrails.md)
+- [Examples](https://github.com/MitulShah1/openai-agents-go/tree/main/examples/08_guardrails_demo)

--- a/docs/ref/index.md
+++ b/docs/ref/index.md
@@ -1,0 +1,232 @@
+# API Reference
+
+Complete API reference for the OpenAI Agents Go SDK.
+
+## Package Structure
+
+```
+github.com/MitulShah1/openai-agents-go
+├── agents              # Core package
+│   ├── Agent          # Agent type and configuration
+│   ├── Runner         # Agent execution orchestration
+│   ├── Tool           # Tool interface and implementations
+│   ├── Result         # Execution results and steps
+│   └── ...
+├── session/            # Session backends
+│   ├── MemorySession
+│   ├── FileSession
+│   └── ConversationsSession
+├── guardrail/          # Guardrail framework
+│   └── builtin/       # Built-in guardrails
+└── internal/           # Internal packages
+    └── jsonschema/    # JSON schema builder
+```
+
+## Core Types
+
+### [Agent](agent.md)
+The central type representing an AI agent with configured behavior.
+
+```go
+type Agent struct {
+    Name            string
+    Instructions    string
+    Model           string
+    Temperature     float64
+    MaxTokens       int
+    Tools           []Tool
+    ResponseFormat  any
+    OnBeforeRun     func(context.Context, *Agent) error
+    OnAfterRun      func(context.Context, *Agent, *Result) error
+}
+```
+
+[View Agent documentation →](agent.md)
+
+### [Runner](runner.md)
+Orchestrates agent execution and manages the interaction loop.
+
+```go
+type Runner struct {
+    // Contains filtered or unexported fields
+}
+
+func NewRunner(client *openai.Client) *Runner
+func (*Runner) Run(
+    ctx context.Context,
+    agent *Agent,
+    messages []openai.ChatCompletionMessageParamUnion,
+    config *RunConfig,
+    options ...RunOption,
+) (*Result, error)
+```
+
+[View Runner documentation →](runner.md)
+
+### [Tool](tool.md)
+Interface for functions that agents can call.
+
+```go
+type Tool interface {
+    ToParam() openai.ChatCompletionToolParam
+    Execute(args string, ctx ContextVariables) (any, error)
+}
+
+// Factory functions
+func FunctionTool(name, description string, schema map[string]any, fn ToolFunction) Tool
+func HandoffTool(agent *Agent, description string) Tool
+```
+
+[View Tool documentation →](tool.md)
+
+### [Result & Types](types.md)
+Execution results, steps, usage tracking, and error types.
+
+```go
+type Result struct {
+    FinalOutput  string
+    Agent        *Agent
+    Steps        []Step
+    Usage        Usage
+    ContextVars  ContextVariables
+}
+
+type Step struct {
+    Index       int
+    AgentName   string
+    Type        string
+    Content     string
+    ToolCalls   []ToolCall
+    Timestamp   time.Time
+}
+
+type Usage struct {
+    PromptTokens     int
+    CompletionTokens int
+    TotalTokens      int
+}
+```
+
+[View Types & Errors documentation →](types.md)
+
+## Advanced Features
+
+### [Guardrails](guardrails/index.md)
+Input/output validation framework with 9+ built-in guardrails.
+
+```go
+type Guardrail interface {
+    Validate(text string, isInput bool) error
+    Name() string
+    IsTripwire() bool
+}
+
+// Built-in guardrails
+func NewPIIGuardrail(name string, isTripwire bool) Guardrail
+func NewModerationGuardrail(name string, client *openai.Client, thresholds map[string]float64, isTripwire bool) Guardrail
+func NewRateLimitGuardrail(name string, limit int, window time.Duration, backend Backend, keyFunc KeyFunc, isTripwire bool) Guardrail
+// ... and 6 more
+```
+
+[View Guardrails documentation →](guardrails/index.md)
+
+### [Sessions](sessions/index.md)
+Conversation persistence with multiple storage backends.
+
+```go
+type Session interface {
+    Load(sessionID string) ([]openai.ChatCompletionMessageParamUnion, error)
+    Save(sessionID string, messages []openai.ChatCompletionMessageParamUnion) error
+}
+
+// Implementations
+func NewMemorySession() Session
+func NewFileSession(directory string) (Session, error)
+func NewConversationsSession(client *openai.Client) (Session, error)
+```
+
+[View Sessions documentation →](sessions/index.md)
+
+## Configuration
+
+### RunConfig
+Control agent execution behavior.
+
+```go
+type RunConfig struct {
+    MaxTurns int           // Maximum tool call iterations
+    Timeout  time.Duration // Overall timeout
+    Debug    bool          // Enable debug logging
+}
+```
+
+### RunOptions
+Functional options for Run method.
+
+```go
+// Available options
+func WithSession(session Session, sessionID string) RunOption
+func WithGuardrails(guardrails []Guardrail) RunOption
+```
+
+## Quick Reference
+
+### Creating an Agent
+```go
+agent := agents.NewAgent("MyAgent")
+agent.Instructions = "You are helpful"
+agent.Model = "gpt-4"
+```
+
+### Running an Agent
+```go
+runner := agents.NewRunner(&client)
+result, err := runner.Run(ctx, agent, messages, config, options...)
+```
+
+### Using Tools
+```go
+tool := agents.FunctionTool("name", "desc", schema, func(args map[string]any, ctx agents.ContextVariables) (any, error) {
+    return result, nil
+})
+agent.Tools = []agents.Tool{tool}
+```
+
+### Using Guardrails
+```go
+guardrails := []agents.Guardrail{
+    builtin.NewPIIGuardrail("PII", true),
+}
+result, err := runner.Run(ctx, agent, messages, nil, agents.WithGuardrails(guardrails))
+```
+
+### Using Sessions
+```go
+sess := session.NewMemorySession()
+result, err := runner.Run(ctx, agent, messages, nil, agents.WithSession(sess, "user-id"))
+```
+
+## External Dependencies
+
+The SDK minimizes dependencies:
+
+### Required
+- `github.com/openai/openai-go` - Official OpenAI Go SDK
+
+### Optional
+- None for core functionality
+- Database drivers for future session backends (v0.3.0+)
+
+## Version Compatibility
+
+| SDK Version | Go Version | OpenAI SDK |
+|-------------|------------|------------|
+| v0.2.3 | 1.24+ | v3.16.0+ |
+| v0.2.0 | 1.24+ | v3.16.0+ |
+| v0.1.0 | 1.24+ | v3.16.0+ |
+
+## See Also
+
+- [GoDoc](https://pkg.go.dev/github.com/MitulShah1/openai-agents-go) - Auto-generated Go documentation
+- [GitHub Examples](https://github.com/MitulShah1/openai-agents-go/tree/main/examples) - Working code samples
+- [CHANGELOG](https://github.com/MitulShah1/openai-agents-go/blob/main/CHANGELOG.md) - Version history

--- a/docs/ref/sessions/index.md
+++ b/docs/ref/sessions/index.md
@@ -1,0 +1,75 @@
+# Sessions API Reference
+
+Complete API reference for the session framework and backends.
+
+## Session Interface
+
+```go
+type Session interface {
+    Load(sessionID string) ([]openai.ChatCompletionMessageParamUnion, error)
+    Save(sessionID string, messages []openai.ChatCompletionMessageParamUnion) error
+}
+```
+
+## Memory Session
+
+In-memory session storage (thread-safe, zero dependencies).
+
+```go
+func NewMemorySession() Session
+```
+
+**Use cases**: Development, testing, single-instance apps
+
+## File Session
+
+File-based JSON storage with atomic writes.
+
+```go
+func NewFileSession(directory string) (Session, error)
+```
+
+**Parameters**:
+- `directory`: Path to store session files
+
+**Use cases**: Single-server production, persistent storage
+
+## Conversations Session
+
+Cloud-based storage using OpenAI Conversations API.
+
+```go
+func NewConversationsSession(client *openai.Client) (Session, error)
+```
+
+**Parameters**:
+- `client`: OpenAI client with API key
+
+**Use cases**: Distributed systems, cloud deployments
+
+## Run Option
+
+Use sessions with agents:
+
+```go
+func WithSession(session Session, sessionID string) RunOption
+```
+
+**Parameters**:
+- `session`: Session backend implementation
+- `sessionID`: Unique identifier for the conversation
+
+## Example
+
+```go
+sess := session.NewMemorySession()
+result, err := runner.Run(
+    ctx, agent, messages, nil,
+    agents.WithSession(sess, "user-123"),
+)
+```
+
+## See Also
+
+- [Sessions Guide](../sessions/index.md)
+- [Examples](https://github.com/MitulShah1/openai-agents-go/tree/main/examples/09_sessions_demo)

--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -1,0 +1,273 @@
+# Sessions
+
+Sessions provide conversation persistence, allowing agents to remember context across multiple interactions.
+
+## Overview
+
+The session framework enables:
+- **Persistent conversation history** across runs
+- **Pluggable storage backends** (in-memory, file, cloud)
+- **Automatic history management** integrated into Runner
+- **Thread-safe concurrent access**
+
+## Available Backends
+
+| Backend | Use Case | Dependencies | Version |
+|---------|----------|--------------|---------|
+| Memory | Testing, development | None | v0.2.0 |
+| File | Single-server production | None | v0.2.0 |
+| Conversations API | Cloud, distributed | OpenAI API key | v0.2.2 |
+| SQLite | Coming soon | None (pure Go) | v0.3.0 |
+| Redis | Coming soon | Redis client | v0.3.0 |
+| PostgreSQL | Coming soon | PostgreSQL driver | v0.3.0 |
+
+## Quick Start
+
+```go
+import "github.com/MitulShah1/openai-agents-go/session"
+
+// Create session
+sess := session.NewMemorySession()
+
+// Run agent with session
+result, err := runner.Run(
+    ctx,
+    agent,
+    messages,
+    nil,
+    agents.WithSession(sess, "user-123"), // Session ID
+)
+```
+
+## Session Backends
+
+### In-Memory Session
+
+Best for development and testing:
+
+```go
+sess := session.NewMemorySession()
+
+// Thread-safe concurrent access
+// Data lost when process ends
+// Zero external dependencies
+```
+
+See [Memory Session Guide](memory_session.md) for details.
+
+### File-Based Session
+
+Best for single-server production:
+
+```go
+import "github.com/MitulShah1/openai-agents-go/session"
+
+sess, err := session.NewFileSession("./sessions")
+if err != nil {
+    panic(err)
+}
+
+// Persists to disk as JSON files
+// Atomic writes prevent corruption
+// Works across process restarts
+```
+
+See [File Session Guide](file_session.md) for details.
+
+### Conversations API
+
+Best for cloud and distributed systems:
+
+```go
+import (
+    "github.com/MitulShah1/openai-agents-go/session"
+    "github.com/openai/openai-go"
+)
+
+client := openai.NewClient(/* ... */)
+
+sess, err := session.NewConversationsSession(&client)
+if err != nil {
+    panic(err)
+}
+
+// Cloud-based persistence via OpenAI
+// Distributed-ready
+// Automatic synchronization
+```
+
+See [Conversations API Guide](conversations_session.md) for details.
+
+## Complete Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    agents "github.com/MitulShah1/openai-agents-go"
+    "github.com/MitulShah1/openai-agents-go/session"
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    client := openai.NewClient(/* ... */)
+    runner := agents.NewRunner(&client)
+
+    agent := agents.NewAgent("Assistant")
+    agent.Instructions = "You are a helpful assistant who remembers context"
+
+    // Create session
+    sess := session.NewMemorySession()
+    sessionID := "user-alice"
+
+    // First interaction
+    result1, _ := runner.Run(
+        context.Background(),
+        agent,
+        []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("My name is Alice and I like Go programming"),
+        },
+        nil,
+        agents.WithSession(sess, sessionID),
+    )
+    fmt.Println("Response 1:", result1.FinalOutput)
+
+    // Second interaction - agent remembers context
+    result2, _ := runner.Run(
+        context.Background(),
+        agent,
+        []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("What's my name and what do I like?"),
+        },
+        nil,
+        agents.WithSession(sess, sessionID),
+    )
+    fmt.Println("Response 2:", result2.FinalOutput)
+    // Output: Your name is Alice and you like Go programming.
+}
+```
+
+## Session Interface
+
+All backends implement the `Session` interface:
+
+```go
+type Session interface {
+    // Load conversation history for a session ID
+    Load(sessionID string) ([]openai.ChatCompletionMessageParamUnion, error)
+    
+    // Save conversation history for a session ID
+    Save(sessionID string, messages []openai.ChatCompletionMessageParamUnion) error
+}
+```
+
+## How Sessions Work
+
+1. **Before agent run**: Runner calls `session.Load(sessionID)` to get history
+2. **History prepended**: Loaded messages are added before new messages
+3. **Agent executes**: With full context from previous interactions
+4. **After completion**: Runner calls `session.Save(sessionID, allMessages)` to persist
+
+```
+User Message → Load History → [History + New Message] → Agent → Save Updated History
+```
+
+## Choosing a Backend
+
+| Scenario | Recommended Backend |
+|----------|-------------------|
+| Local development | Memory Session |
+| Unit tests | Memory Session |
+| Single-server app | File Session |
+| Multi-server app | Conversations API |
+| Cloud deployment | Conversations API |
+| High scalability | Redis (v0.3.0) |
+| Enterprise | PostgreSQL (v0.3.0) |
+
+## Best Practices
+
+### Session IDs
+
+Use meaningful, unique session IDs:
+
+```go
+// ✅ Good: User-specific
+sessionID := fmt.Sprintf("user-%s", userID)
+
+// ✅ Good: Conversation-specific
+sessionID := fmt.Sprintf("conv-%s", conversationID)
+
+// ❌ Bad: Not unique
+sessionID := "session"
+```
+
+### Memory Management
+
+For file-based sessions, consider periodic cleanup:
+
+```go
+// Delete old sessions
+sess.Delete(oldSessionID)
+```
+
+For memory sessions, clear when done:
+
+```go
+// Clear all sessions
+sess = session.NewMemorySession()
+```
+
+### Error Handling
+
+Always check session errors:
+
+```go
+result, err := runner.Run(
+    ctx, agent, messages, nil,
+    agents.WithSession(sess, sessionID),
+)
+if err != nil {
+    // Session save/load errors are wrapped
+    fmt.Println("Session error:", err)
+}
+```
+
+## Advanced Topics
+
+### Manual Session Control
+
+You can manually load/save sessions:
+
+```go
+// Load manually
+history, err := sess.Load("user-123")
+
+// Modify history
+history = append(history, openai.UserMessage("New message"))
+
+// Save manually
+err = sess.Save("user-123", history)
+```
+
+### Session Migration
+
+Coming in v0.3.0: Migrate between backends
+
+```go
+// Future API (v0.3.0)
+err := session.Migrate(fileSession, redisSession, "user-123")
+```
+
+## API Reference
+
+See [Sessions API Reference](../ref/sessions/index.md) for detailed API documentation.
+
+## Related Topics
+
+- [Memory Session](memory_session.md)
+- [File Session](file_session.md)
+- [Conversations API Session](conversations_session.md)
+- [Running Agents](../running_agents.md)

--- a/docs/structured_outputs.md
+++ b/docs/structured_outputs.md
@@ -1,0 +1,56 @@
+# Structured Outputs
+
+Get type-safe JSON responses from agents with schema validation.
+
+## Overview
+
+Structured outputs ensure agents return JSON that matches your schema, enabling reliable parsing and type safety.
+
+## Quick Example
+
+```go
+import "github.com/MitulShah1/openai-agents-go/internal/jsonschema"
+
+// Define schema
+schema := jsonschema.Object().
+    WithProperty("answer", jsonschema.Integer()).
+    WithProperty("reasoning", jsonschema.String()).
+    WithRequired("answer", "reasoning")
+
+// Create agent with structured output
+agent := agents.NewAgent("Math Tutor")
+agent.ResponseFormat = jsonschema.JSONSchema("math_response", schema)
+
+// Parse response
+type MathResponse struct {
+    Answer    int    `json:"answer"`
+    Reasoning string `json:"reasoning"`
+}
+```
+
+## Schema Builder
+
+The `jsonschema` package provides a fluent API for building schemas:
+
+```go
+// Object with properties
+schema := jsonschema.Object().
+    WithProperty("name", jsonschema.String()).
+    WithProperty("age", jsonschema.Integer()).
+    WithRequired("name")
+
+// Arrays
+jsonschema.Array(jsonschema.String())
+
+// Enums
+jsonschema.String().WithEnum("small", "medium", "large")
+```
+
+## Complete Examples
+
+See examples:- `examples/06_structured_output/` - Basic usage
+- `examples/07_complex_schema/` - Nested schemas
+
+## API Reference
+
+See [API Reference](ref/types.md) for detailed documentation.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,64 @@
+# Tools
+
+Tools enable agents to perform actions by calling Go functions.
+
+## Overview
+
+Tools are functions that agents can discover and call during execution. The SDK provides a simple interface for creating and using tools.
+
+## Creating a Tool
+
+### Function Tool
+
+The most common type of tool wraps a Go function:
+
+```go
+weatherTool := agents.FunctionTool(
+    "get_weather",
+    "Get the current weather for a city",
+    map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "city": map[string]any{
+                "type":        "string",
+                "description": "The city name",
+            },
+        },
+        "required": []string{"city"},
+    },
+    func(args map[string]any, ctx agents.ContextVariables) (any, error) {
+        city := args["city"].(string)
+        // Call weather API
+        return fmt.Sprintf("Weather in %s is sunny", city), nil
+    },
+)
+```
+
+### Handoff Tool
+
+Transfer control to another agent:
+
+```go
+handoff := agents.HandoffTool(specialistAgent, "Transfer to specialist")
+```
+
+## Tool Interface
+
+All tools implement the `Tool` interface:
+
+```go
+type Tool interface {
+    ToParam() openai.ChatCompletionToolParam
+    Execute(args string, ctx ContextVariables) (any, error)
+}
+```
+
+## Complete Example
+
+See [Quickstart Guide](quickstart.md#adding-tools) and [API Reference](ref/tool.md) for more details.
+
+## Related Topics
+
+- [Agents](agents.md)
+- [Handoffs](handoffs.md)
+- [Context Variables](context.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,107 @@
+site_name: OpenAI Agents Go SDK
+site_description: Community-maintained Go SDK for building AI agents with OpenAI's API
+site_url: https://mitulshah1.github.io/openai-agents-go/
+repo_name: MitulShah1/openai-agents-go
+repo_url: https://github.com/MitulShah1/openai-agents-go
+
+theme:
+  name: material
+  features:
+    # Allows copying code blocks
+    - content.code.copy
+    # Allows selecting code blocks
+    - content.code.select
+    # Shows the current path in the sidebar
+    - navigation.path
+    # Shows sections in the sidebar
+    - navigation.sections
+    # Shows sections expanded by default
+    - navigation.expand
+    # Enables annotations in code blocks
+    - content.code.annotate
+    # Top navigation tabs
+    - navigation.tabs
+    # Instant loading
+    - navigation.instant
+  palette:
+    primary: indigo
+    accent: indigo
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: false
+
+markdown_extensions:
+  # Code highlighting
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  # Admonitions (notes, warnings, etc.)
+  - admonition
+  - pymdownx.details
+  # Better lists
+  - def_list
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  # Tabs
+  - pymdownx.tabbed:
+      alternate_style: true
+  # Better tables
+  - tables
+  # Footnotes
+  - footnotes
+  # Abbreviations
+  - abbr
+  # Icons and emojis
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Core Concepts:
+      - Agents: agents.md
+      - Tools: tools.md
+      - Running Agents: running_agents.md
+      - Handoffs: handoffs.md
+      - Context Variables: context.md
+      - Results: results.md
+  - Advanced Features:
+      - Structured Outputs: structured_outputs.md
+      - Guardrails: guardrails.md
+      - Multi-Agent Workflows: multi_agent.md
+      - Sessions:
+          - Overview: sessions/index.md
+          - Memory Session: sessions/memory_session.md
+          - File Session: sessions/file_session.md
+          - Conversations API: sessions/conversations_session.md
+      - Configuration: config.md
+      - Usage Tracking: usage.md
+  - API Reference:
+      - Overview: ref/index.md
+      - Agent: ref/agent.md
+      - Runner: ref/runner.md
+      - Tool: ref/tool.md
+      - Types & Errors: ref/types.md
+      - Guardrails: ref/guardrails/index.md
+      - Sessions: ref/sessions/index.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/MitulShah1/openai-agents-go
+  version:
+    provider: mike


### PR DESCRIPTION
- Add CHANGELOG.md with complete version history (v0.1.0 to v0.2.3)
- Set up MkDocs Material with professional documentation theme
- Create 10+ documentation files covering:
  - Landing page and quickstart guide
  - Core concepts (agents, tools, guardrails, sessions)
  - Advanced features and API references
- Add GitHub Actions workflow for automated deployment to GitHub Pages
- Update README.md with documentation site link
- Refactor ROADMAP.md to focus on future plans (historical details moved to CHANGELOG)
- Add documentation maintenance guidelines to AGENT.md

Closes #[issue-number if applicable]