### PR TITLE
Return an error from WithEncryption for invalid keys

### DIFF
--- a/docs/sessions/index.md
+++ b/docs/sessions/index.md
@@ -337,7 +337,10 @@ Secure your conversation history with AES-GCM encryption.
 ```go
 key := []byte("your-32-byte-secret-key-12345678")
 // Wrap session with encryption (requires 16, 24, or 32 byte key)
-sess = session.WithEncryption(baseSession, key)
+sess, err = session.WithEncryption(baseSession, key)
+if err != nil {
+    return err
+}
 ```
 
 ### Composition
@@ -349,7 +352,10 @@ Utilities can be composed. For "Compress then Encrypt" strategy (recommended):
 store, _ := session.NewSQLite("chats.db")
 
 // 1. Encryption wraps the store (Inner)
-encrypted := session.WithEncryption(store, key)
+encrypted, err := session.WithEncryption(store, key)
+if err != nil {
+    return err
+}
 
 // 2. Compression wraps the encrypted session (Outer)
 finalSession := session.WithCompression(encrypted)

--- a/session/compression_test.go
+++ b/session/compression_test.go
@@ -130,7 +130,10 @@ func TestCombinedUtilities(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	encrypted := WithEncryption(mem, key)
+	encrypted, err := WithEncryption(mem, key)
+	if err != nil {
+		t.Fatal(err)
+	}
 	compressed := WithCompression(encrypted)
 
 	sessionID := "combined-session"

--- a/session/encryption.go
+++ b/session/encryption.go
@@ -24,22 +24,22 @@ type encryptedSession struct {
 
 // WithEncryption wraps a session backend with AES-GCM encryption.
 // The key must be 16, 24, or 32 bytes for AES-128, AES-192, or AES-256.
-// Panics if the key is invalid or cipher block cannot be created.
-func WithEncryption(s Session, key []byte) Session {
+// Returns an error if the key is invalid or cipher block cannot be created.
+func WithEncryption(s Session, key []byte) (Session, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create cipher: %v", err))
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		panic(fmt.Sprintf("failed to create GCM: %v", err))
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
 	}
 
 	return &encryptedSession{
 		inner: s,
 		gcm:   gcm,
-	}
+	}, nil
 }
 
 func (s *encryptedSession) Get(ctx context.Context, sessionID string) ([]openai.ChatCompletionMessageParamUnion, error) {

--- a/session/encryption_test.go
+++ b/session/encryption_test.go
@@ -18,7 +18,10 @@ func TestWithEncryption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	encrypted := WithEncryption(mem, key)
+	encrypted, err := WithEncryption(mem, key)
+	if err != nil {
+		t.Fatal(err)
+	}
 	sessionID := "enc-session"
 
 	t.Run("basic append and get", func(t *testing.T) {
@@ -54,14 +57,11 @@ func TestWithEncryption(t *testing.T) {
 	})
 
 	t.Run("invalid key length", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Error("Expected panic for invalid key length, got none")
-			}
-		}()
 		// Key must be 16, 24, or 32 bytes
 		badKey := make([]byte, 10)
-		WithEncryption(mem, badKey)
+		if _, err := WithEncryption(mem, badKey); err == nil {
+			t.Error("Expected error for invalid key length, got nil")
+		}
 	})
 
 	t.Run("mixed content handling", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Change `WithEncryption` to return `(Session, error)` instead of panicking when AES-GCM setup fails.
- Preserve successful encryption behavior while surfacing invalid key lengths as construction-time errors.
- Update session tests, compression composition tests, and session documentation for the new API.

## Testing
- `gofmt -w session/encryption.go session/encryption_test.go session/compression_test.go`
- `go test ./...`
- `git diff --check`

Closes #104.

*This PR was developed by Codex with supervision from jmtdev0.*
